### PR TITLE
angle brackets need to be escaped in HTML, removed invalid 'tag'

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -25,7 +25,7 @@ fn run() -> Result<()> {
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 <head><title></title></head>
 <body>
-<p>Text of the page<T></p>
+<p>Text of the page</p>
 </body>
 </html>"#;
     let dummy_content_with_id = dummy_content.replace("<p>", "<p id=\"p1\">");


### PR DESCRIPTION
I was trying out https://github.com/lise-henry/epub-builder 
and thought I would try your fixed example in my epub reader.

Here's a simple fix to the invalid HTML which allows the output to be opened in iBooks.

Thanks for making this PR!